### PR TITLE
[RFR] Add security to url calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ stop: ## Stop the server
 
 test: ## Test the code
 	docker-compose run --no-deps --rm php bin/phpunit
+
+deploy: ## Deploy on AWS
+	scp -v -r ./* quarto-go:~/quarto-symphony/

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,3 @@ stop: ## Stop the server
 
 test: ## Test the code
 	docker-compose run --no-deps --rm php bin/phpunit
-
-deploy: ## Deploy on AWS
-	scp -v -r ./* quarto-go:~/quarto-symphony/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - "8081:8081"
+      - "80:80"
     volumes:
       - ./quarto:/quarto
       - ./docker/nginx/site.conf:/etc/nginx/conf.d/default.conf

--- a/docker/nginx/site.conf
+++ b/docker/nginx/site.conf
@@ -1,5 +1,5 @@
 server {
-    listen 8081;
+    listen 80;
     server_name quarto-symfony;
     root /quarto/public/;
 

--- a/quarto/config/packages/dev/web_profiler.yaml
+++ b/quarto/config/packages/dev/web_profiler.yaml
@@ -1,5 +1,5 @@
 web_profiler:
-    toolbar: true
+    toolbar: false
     intercept_redirects: false
 
 framework:

--- a/quarto/config/packages/dev/web_profiler.yaml
+++ b/quarto/config/packages/dev/web_profiler.yaml
@@ -1,5 +1,5 @@
 web_profiler:
-    toolbar: false
+    toolbar: true
     intercept_redirects: false
 
 framework:

--- a/quarto/config/routes.yaml
+++ b/quarto/config/routes.yaml
@@ -26,3 +26,9 @@ game_place:
         idGame: '\d+'
         x: '\d+'
         y: '\d+'
+
+all:
+  path: /{req}
+  defaults: { _controller: 'App\Controller\DefaultController::index' }
+  requirements:
+      req: ".+"

--- a/quarto/src/Api/GameManager.php
+++ b/quarto/src/Api/GameManager.php
@@ -20,14 +20,23 @@ class GameManager {
         return $game;
     }
 
-    public function playPieceSelection(Game $game, int $piece) {
+    public function playPieceSelection(Game $game, int $piece) : bool{
+        if ($game->getSelectedPiece() != 0) {
+            return false;
+        }
         $game->selectNextPiece($piece);
         $game->changeTurn();
         $this->gameRepository->save($game);
+        return true;
     }
 
-    public function playPiecePLacement(Game $game, int $x, int $y) {
+    public function playPiecePLacement(Game $game, int $x, int $y) : bool{
+        $grid = $game->getGrid();
+        if ($grid[$y][$x] != ".") {
+            return false;
+        }
         $game->placePiece($x, $y);
         $this->gameRepository->save($game);
+        return true;
     }
 }

--- a/quarto/src/Controller/DefaultController.php
+++ b/quarto/src/Controller/DefaultController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use App\Api\GameManager;
+use App\Entity\Game;
+use App\Repository\GameRepository;
+use App\Api\CookieManager;
+
+class DefaultController extends Controller {
+
+  private $twig;
+
+  public function __construct(\Twig_Environment $twig) {
+    $this->twig = $twig;
+  }
+  
+  public function index(Request $request) {
+    return new Response($this->twig->render('unknown.html.twig'));
+  }
+}

--- a/quarto/src/Repository/GameRepository.php
+++ b/quarto/src/Repository/GameRepository.php
@@ -15,7 +15,7 @@ class GameRepository extends EntityRepository {
     $this->em = $em;
   }
 
-  public function findGameById(string $id) : Game {
+  public function findGameById(string $id) {
     return $this->em->find('App:Game', $id);
   }
 

--- a/quarto/templates/base.html.twig
+++ b/quarto/templates/base.html.twig
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Refresh" content="5">
     <title>{% block pageTitle %}Quarto online!{% endblock %}</title>
     <link rel="icon" type="image/x-icon" href="{{ asset('images/favicon.ico') }}" />
     {% block refresh %}{% endblock %}

--- a/quarto/templates/game.html.twig
+++ b/quarto/templates/game.html.twig
@@ -1,4 +1,9 @@
 {% extends "base.html.twig" %}
+{% block refresh %}
+  {% if (canPlay == false) %}
+    <meta http-equiv="Refresh" content="2">
+  {% endif %}
+{% endblock %}
 {% block header %}
   <div class="section">
     <h4>Welcome to Quarto online !</h4>
@@ -13,7 +18,7 @@
         'grid': game.getGrid(), 
         'pieceSelected' : game.getSelectedPiece(),
         'winningLine' : game.getWinningLine(),
-        'canPlay' : (playerId == 1 and game.getIsPlayerOneTurn()) or (playerId == 2 and game.getIsPlayerOneTurn() == false)} %}
+        'canPlay' : canPlay} %}
     </div>
     <div>
       {% include 'pieces.html.twig' with {
@@ -21,7 +26,7 @@
         'pieces': pieces, 
         'pieceSelected' : game.getSelectedPiece(),
         'winningLine' : game.getWinningLine(),
-        'canPlay' : (playerId == 1 and game.getIsPlayerOneTurn()) or (playerId == 2 and game.getIsPlayerOneTurn() == false)} %}
+        'canPlay' : canPlay} %}
     </div>
     <div>
       {% include 'players.html.twig' with {
@@ -30,7 +35,7 @@
         'player1Name' : 'Player 1',
         'player2Name' : 'Player 2',
         'winningLine' : game.getWinningLine(),
-        'canPlay' : (playerId == 1 and game.getIsPlayerOneTurn()) or (playerId == 2 and game.getIsPlayerOneTurn() == false),
+        'canPlay' : canPlay,
         'playerId' : playerId} %}
     </div>
   </div>

--- a/quarto/templates/unknown.html.twig
+++ b/quarto/templates/unknown.html.twig
@@ -1,0 +1,14 @@
+{% extends "base.html.twig" %}
+{% block header %}
+  <div class="section">
+    <h4>Welcome to Quarto online !</h4>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <div class="board">
+    <br/>
+    <br/>
+    <span>The game asked doesn't exists or  asked instruction isn't allowed !!</span>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Bad urls and bad game commands leads now to a specific error page

Making "bad moves" in the game, like placing a piece in a occupied case isn't allowed
(Web interface has never allowed it but url manipulation coul'd have allowed it)

The user whose turn is active doesn't refesh screen anymore, only wait players refresh their screens