### PR TITLE
[RFR] Allow lists return without giving token to API

### DIFF
--- a/quarto/config/routes.yaml
+++ b/quarto/config/routes.yaml
@@ -10,6 +10,11 @@ gameapi:
     resource: '../src/Controller/GameApi/gameApiRouting.yml'
     prefix:   /gameapi
 
+gameapi_new:
+  path: /gameapi
+  controller: 'App\Controller\GameApi\GameApiController::new'
+
+
 all:
   path: /{req}
   defaults: { _controller: 'App\Controller\DefaultController::index' }

--- a/quarto/src/Controller/GameApi/gameApiRouting.yml
+++ b/quarto/src/Controller/GameApi/gameApiRouting.yml
@@ -1,7 +1,3 @@
-gameapi_new:
-  path: /
-  controller: 'App\Controller\GameApi\GameApiController::new'
-
 gameapi_new_solo:
   path: /solo
   controller: 'App\Controller\GameApi\GameApiController::newSolo'

--- a/quarto/src/Repository/GameRepository.php
+++ b/quarto/src/Repository/GameRepository.php
@@ -20,6 +20,9 @@ class GameRepository extends EntityRepository {
   }
 
   public function getOpenedGamesList(array $tokenList) {
+    if (count($tokenList) === 0) {
+      $tokenList=["NOTHING"];
+    }
     $query = $this->em->createQuery("SELECT g FROM App:Game g  " .
     "WHERE g.closed=false " .
     "AND g.number_players = 1 " .
@@ -43,6 +46,9 @@ class GameRepository extends EntityRepository {
   }
 
   public function getOnlySpectateGamesList(array $tokenList) {
+    if (count($tokenList) === 0) {
+      $tokenList=["NOTHING"];
+    }
     $query = $this->em->createQuery("SELECT g FROM App:Game g  " .
     "WHERE g.closed=false  " .
     "AND g.number_players = 2 " .


### PR DESCRIPTION
When list is called via API, and no token are given in url, returned lists were always empty.
Now, they are correct.